### PR TITLE
Fix usage with emulators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,4 +32,4 @@ lazy_static = "1.4.0"
 [dev-dependencies]
 assert_cmd = "2.0.8"
 indoc = "2.0.1"
-predicates = "2.1.5"
+predicates = "3.0.4"

--- a/create_debug_extcap.sh
+++ b/create_debug_extcap.sh
@@ -8,10 +8,10 @@ set -ex
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 # NOTE: Change to ~/.local/lib/wireshark/extcap if using Wireshark 4.1 or above
-cat <<EOF > ~/.config/wireshark/extcap/btsnoop-extcap
+cat <<EOF > ~/.local/lib/wireshark/extcap/btsnoop-extcap
 #! /usr/bin/env bash
 exec 2>/tmp/btsnoop-extcap.log
 # Use exec to make sure the rust program will get SIGTERM from wireshark when stopping
-RUST_LOG=debug exec $SCRIPT_DIR/../target/debug/btsnoop-extcap "\$@"
+RUST_LOG=debug exec $SCRIPT_DIR/target/debug/btsnoop-extcap "\$@"
 EOF
-chmod +x ~/.config/wireshark/extcap/btsnoop-extcap
+chmod +x ~/.local/lib/wireshark/extcap/btsnoop-extcap

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 #![deny(unused_must_use)]
 
 use adb::{AdbRootError, BtsnoopLogMode, BtsnoopLogSettings};
+use anyhow::anyhow;
 use btsnoop::{FileHeader, PacketHeader};
 use btsnoop_ext::Direction;
 use clap::Parser;
@@ -240,11 +241,9 @@ async fn main() -> anyhow::Result<()> {
         ExtcapStep::ReloadConfig(_) => {}
         ExtcapStep::Capture(mut capture_step) => {
             let interface = capture_step.interface;
-            assert!(
-                interface.starts_with("btsnoop-"),
-                "Interface must start with \"btsnoop-\""
-            );
-            let serial = interface.split('-').nth(1).unwrap();
+            let serial = interface
+                .strip_prefix("btsnoop-")
+                .ok_or_else(|| anyhow!("Interface must start with \"btsnoop-\""))?;
             let extcap_reader = capture_step.new_control_reader_async().await;
             let extcap_sender: Mutex<Option<ExtcapControlSender>> =
                 Mutex::new(capture_step.new_control_sender_async().await);


### PR DESCRIPTION
Emulators contain "-" in their "serial numbers". Fix the regex matching and the extcap argument handling to handle that case.